### PR TITLE
XSD Schema Change

### DIFF
--- a/cmgibs/gibs.py
+++ b/cmgibs/gibs.py
@@ -9,7 +9,8 @@ import urllib.request
 class GibsColormap(object):
 
     # open the XML schema with urllib, parse it with lxml
-    raw_xsd = urllib.request.urlopen('http://gibs.earthdata.nasa.gov/schemas/ColorMap_v1.3.xsd')
+    xsd_url = 'https://raw.githubusercontent.com/nasa-gibs/onearth/master/src/colormaps/schemas/ColorMap_v1.3.xsd'
+    raw_xsd = urllib.request.urlopen(xsd_url)
     XSD = lxml.etree.XMLSchema(lxml.etree.parse(raw_xsd))
 
     def __init__(self, req, name):


### PR DESCRIPTION
The URL to the v1.3 .xsd GIBS colormap schema was returning a 404, so I had to find a new URL to get the XSD from. This one comes from the GIBS GitHub repo, which will probably remain fairly stable. Another option is to download the .xsd locally and keep in in here.